### PR TITLE
Support processing base64-encoded image from stdin and outputting to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Add prefix or suffix to output files. (default suffix: **_rounded**)
 $ round -p new -s _circle /path/to/square.png
 ```
 
+Supply the image in base64 format through stdin. (processed image will be printed on stdout)
+
+```shell
+$ cat base64image | round -b
+```
+
 ##  Examples
 
 |          | rect+jpg                                                 | rect+png                                                 | square+jpg                                                 | square+png                                                 |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $ round -p new -s _circle /path/to/square.png
 Supply the image in base64 format through stdin. (processed image will be printed on stdout)
 
 ```shell
+# the file *must* have a new line at the end
 $ cat base64image | round -b
 ```
 

--- a/image.go
+++ b/image.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/base64"
 	"image"
 	"image/jpeg"
 	"image/png"
+	"io"
 	"os"
 )
 
@@ -16,6 +19,24 @@ func encode(fm string, f *os.File, m image.Image) error {
 	default:
 		return errInvalidFormat
 	}
+}
+
+func encodeBase64(fm string, m image.Image) (string, error) {
+	buf := new(bytes.Buffer)
+	err := errInvalidFormat
+	var prefix string
+	switch fm {
+	case "png":
+		prefix = "data:image/png;base64,"
+		err = png.Encode(buf, m)
+	case "jpg", "jpeg":
+		prefix = "data:image/jpeg;base64,"
+		err = jpeg.Encode(buf, m, nil)
+	}
+	if err != nil {
+		return "", err
+	}
+	return prefix + base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }
 
 func decode(r io.Reader) (image.Image, string, error) {

--- a/image.go
+++ b/image.go
@@ -18,8 +18,8 @@ func encode(fm string, f *os.File, m image.Image) error {
 	}
 }
 
-func decode(f *os.File) (image.Image, string, error) {
-	m, fm, err := image.Decode(f)
+func decode(r io.Reader) (image.Image, string, error) {
+	m, fm, err := image.Decode(r)
 	switch fm {
 	case "png", "jpg", "jpeg":
 		return m, fm, err

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/base64"
 	"errors"
 	"flag"
+	"fmt"
 	"image"
 	"image/color"
 	"log"
@@ -60,6 +62,21 @@ func parsePaths(paths []string) ([]string, error) {
 
 func process(path string, opts *option, wg *sync.WaitGroup) {
 	defer wg.Done()
+
+	if opts.base64 {
+		reader := base64.NewDecoder(base64.StdEncoding, strings.NewReader(path))
+		m, fm, err := decode(reader)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		convert(&m, opts)
+		out, err := encodeBase64(fm, m)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		fmt.Print(out)
+		return
+	}
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -21,6 +22,7 @@ var (
 	errInvalidFormat = errors.New("invalid image format")
 	errInvalidRate   = errors.New("invalid rounding rate")
 	errInvalidCorner = errors.New("invalid corner value")
+	base64Regex      = regexp.MustCompile(`(?m)data:image\/(png|jpe?g);base64,`)
 )
 
 // Settable has a Set method to set the color for a point.
@@ -40,6 +42,9 @@ func main() {
 		rawBase64, err := reader.ReadString('\n')
 		if err != nil {
 			log.Fatalln(err)
+		}
+		if strings.HasPrefix(rawBase64, "data:image/") {
+			rawBase64 = base64Regex.ReplaceAllString(rawBase64, "")
 		}
 		wg.Add(1)
 		process(strings.TrimSpace(rawBase64), opts, wg)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/base64"
 	"errors"
 	"flag"
@@ -31,18 +32,28 @@ var empty = color.RGBA{255, 255, 255, 0}
 
 func main() {
 	opts := parseOptions()
-
-	paths, err := parsePaths(flag.Args())
-	if err != nil {
-		log.Fatalln(err)
-	}
-
 	wg := new(sync.WaitGroup)
-	for _, p := range paths {
+
+	// TODO: support multiple base64 images..?
+	if opts.base64 {
+		reader := bufio.NewReader(os.Stdin)
+		rawBase64, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatalln(err)
+		}
 		wg.Add(1)
-		go process(p, opts, wg)
+		process(strings.TrimSpace(rawBase64), opts, wg)
+	} else {
+		paths, err := parsePaths(flag.Args())
+		if err != nil {
+			log.Fatalln(err)
+		}
+		for _, p := range paths {
+			wg.Add(1)
+			go process(p, opts, wg)
+		}
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 func parsePaths(paths []string) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	opts := parseOptions()
 	wg := new(sync.WaitGroup)
 
-	// TODO: support multiple base64 images..?
+	// if we're in base64 mode, read data from stdin once and process it
 	if opts.base64 {
 		reader := bufio.NewReader(os.Stdin)
 		rawBase64, err := reader.ReadString('\n')
@@ -79,6 +79,8 @@ func parsePaths(paths []string) ([]string, error) {
 func process(path string, opts *option, wg *sync.WaitGroup) {
 	defer wg.Done()
 
+	// if we're in base64 mode, decode data from 'path', convert it, encode
+	// it back to base64 and print to stdout, otherwise convert it normally
 	if opts.base64 {
 		reader := base64.NewDecoder(base64.StdEncoding, strings.NewReader(path))
 		m, fm, err := decode(reader)

--- a/option.go
+++ b/option.go
@@ -16,6 +16,7 @@ type corner struct {
 type option struct {
 	rate   float64
 	owrite bool
+	base64 bool
 	output string
 	prefix string
 	suffix string

--- a/option.go
+++ b/option.go
@@ -40,7 +40,7 @@ func parseOptions() *option {
 	rate := flag.Float64("r", opts.rate, "rounding rate. 1 means circular. (0~1)")
 	corner := flag.String("c", "tl,tr,bl,br", "comma separated corners to round.")
 	owrite := flag.Bool("w", false, "if true, will overwrite the original files.")
-	base64 := flag.Bool("b", false, "if true, will read base64-encoded bytes from stdin.")
+	base64 := flag.Bool("b", false, "if true, will read base64-encoded bytes from stdin and print output to stdout.")
 	output := flag.String("o", opts.output, "output file name for a single file.")
 	prefix := flag.String("p", opts.prefix, "prefix for the output file names.")
 	suffix := flag.String("s", opts.suffix, "suffix for the output file names.")

--- a/option.go
+++ b/option.go
@@ -40,6 +40,7 @@ func parseOptions() *option {
 	rate := flag.Float64("r", opts.rate, "rounding rate. 1 means circular. (0~1)")
 	corner := flag.String("c", "tl,tr,bl,br", "comma separated corners to round.")
 	owrite := flag.Bool("w", false, "if true, will overwrite the original files.")
+	base64 := flag.Bool("b", false, "if true, will read base64-encoded bytes from stdin.")
 	output := flag.String("o", opts.output, "output file name for a single file.")
 	prefix := flag.String("p", opts.prefix, "prefix for the output file names.")
 	suffix := flag.String("s", opts.suffix, "suffix for the output file names.")
@@ -54,6 +55,7 @@ func parseOptions() *option {
 		log.Fatalln(err)
 	}
 	opts.owrite = *owrite
+	opts.base64 = *base64
 	opts.output = *output
 	opts.prefix = *prefix
 	opts.suffix = *suffix


### PR DESCRIPTION
This modification allows you to more efficiently process images without having to write them to disk.

The need for this came from needing rounded images in my Node.js API but not being able to find any suitable libraries.

At the moment it's only possible to process one image at a time. Although it's totally possible to implement multi-image processing, I don't see a reason to, as the current solution is already pretty fast.

Example usage in Node.js (TypeScript):
```ts
function roundImage(base64: string): Promise<string> {
    return new Promise((resolve, reject) => {
        let proc = spawn('./util/bin/round', ['-b', '-r', '0.1'])

        let stdout: string = ''
        let stderr: string = ''

        proc.stdout.on('data', (data) => {
            stdout += data
        })

        proc.stderr.on('data', (data) => {
            stderr += data
        })

        proc.on('close', (exitCode: number) => {
            if (exitCode != 0) {
                return reject(stderr)
            }
            resolve(stdout)
        })

        proc.stdin.setDefaultEncoding('utf-8')

        proc.stdin.write(base64 + '\n')

        proc.stdin.end()
    })
}
```

It also works in the shell (the file *must* have a new line at the end though):

```shell
$ cat original-image | round -b > rounded-image
```